### PR TITLE
symlink python

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,16 +10,16 @@ RUN sudo apt-get -q update && \
     sudo apt-get clean && sudo apt-get -y autoremove && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # For Trellis CLI, specifically: `trellis init`
-RUN pip3 install --no-cache-dir virtualenv
+RUN pip install --no-cache-dir virtualenv
 
 # Trellis CLI
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sL https://roots.io/trellis/cli/get | bash -s -- -d -b ~/bin
 
 # # Basic smoke test
-RUN echo "python3 --version" && python3 --version && \
-    echo "pip3 --version" && pip3 --version && \
-    echo "pip3 check" && pip3 check && \
+RUN echo "python --version" && python --version && \
+    echo "pip --version" && pip --version && \
+    echo "pip check" && pip check && \
     echo "virtualenv --version" && virtualenv --version && \
     echo "rsync --version" && rsync --version && \
     echo "trellis --version" && trellis --version

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,9 @@ FROM "cimg/python:${PYTHON_MINOR_VERSION}"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# For Ansible git module
+RUN sudo ln -s "$(which python)" /usr/bin/python
+
 # For Trellis, specifically: Ansible's synchronize module
 RUN sudo apt-get -q update && \
     sudo apt-get install -q -y --no-install-recommends rsync && \
@@ -18,6 +21,8 @@ RUN curl -sL https://roots.io/trellis/cli/get | bash -s -- -d -b ~/bin
 
 # # Basic smoke test
 RUN echo "python --version" && python --version && \
+    echo "which python" && \
+    echo "/usr/bin/python --version" && \
     echo "pip --version" && pip --version && \
     echo "pip check" && pip check && \
     echo "virtualenv --version" && virtualenv --version && \


### PR DESCRIPTION
- Normalize python3 and pip3
- Symlink `python` to `/usr/bin/python` for Ansible git module

--- 

```
TASK [deploy : Clone project files] **************************************************************************************************************
task path: /home/circleci/project/trellis/deploy-hooks/build-before.yml:11
Using module file /home/circleci/project/trellis/.trellis/virtualenv/lib/python3.8/site-packages/ansible/modules/git.py
Pipelining is enabled.
<34.89.65.134> ESTABLISH LOCAL CONNECTION FOR USER: circleci
<34.89.65.134> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
System info:
  Ansible 2.10.1; Linux
  Trellis version (per changelog): "Removes ID from Lets Encrypt bundled certificate and make filename stable"
---------------------------------------------------
The module failed to execute correctly, you probably need to set the
interpreter.
See stdout/stderr for the exact error
/bin/sh: 1: /usr/bin/python: not found
fatal: [kinsta_production]: FAILED! => {
    "changed": false,
    "module_stdout": "",
    "rc": 127
}
```