### PR TITLE
Hardcode `PYTHON_MINOR_VERSION` for dependabot; Dependabot: Remove unnecessary config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,8 @@ updates:
     directory: "base"
     schedule:
       interval: daily
-      time: "19:50"
-      timezone: Europe/London
 
   - package-ecosystem: docker
     directory: "node"
     schedule:
       interval: daily
-      time: "19:50"
-      timezone: Europe/London

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,4 @@
-ARG PYTHON_MINOR_VERSION=3.8
-
-FROM "cimg/python:${PYTHON_MINOR_VERSION}"
+FROM cimg/python:3.8
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
- Hardcode `PYTHON_MINOR_VERSION` for dependabot
- Dependabot: Remove unnecessary config
